### PR TITLE
Reintroduce coap2coap proxy functionality

### DIFF
--- a/cf-proxy/pom.xml
+++ b/cf-proxy/pom.xml
@@ -24,12 +24,12 @@
 		<dependency>
 			<groupId>org.eclipse.californium</groupId>
 			<artifactId>californium-core</artifactId>
-			<version>2.0.0-M4</version>
+			<version>2.0.0-M6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.californium</groupId>
 			<artifactId>californium-proxy</artifactId>
-			<version>2.0.0-M4</version>
+			<version>2.0.0-M6</version>
 		</dependency>
 	</dependencies>
 

--- a/cf-proxy/src/main/java/org/eclipse/californium/examples/ExampleCrossProxy.java
+++ b/cf-proxy/src/main/java/org/eclipse/californium/examples/ExampleCrossProxy.java
@@ -21,9 +21,17 @@ import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 
 import org.eclipse.californium.proxy.resources.ForwardingResource;
+import org.eclipse.californium.proxy.resources.ProxyCoapClientResource;
 import org.eclipse.californium.proxy.resources.ProxyHttpClientResource;
 
 /**
+ * Http2CoAP: Insert in browser:
+ *     URI: http://localhost:8080/proxy/coap://localhost:PORT/target
+ *
+ * CoAP2CoAP: Insert in Copper:
+ *     URI: coap://localhost:PORT/coap2coap
+ *     Proxy: coap://localhost:PORT/targetA
+ *
  * CoAP2Http: Insert in Copper:
  *     URI: coap://localhost:PORT/coap2http
  *     Proxy: http://lantersoft.ch/robots.txt
@@ -35,10 +43,12 @@ public class ExampleCrossProxy {
 	private CoapServer targetServerA;
 
 	public ExampleCrossProxy() throws IOException {
+		ForwardingResource coap2coap = new ProxyCoapClientResource("coap2coap");
 		ForwardingResource coap2http = new ProxyHttpClientResource("coap2http");
 
 		// Create CoAP Server on PORT with proxy resources form CoAP to CoAP and HTTP
 		targetServerA = new CoapServer(PORT);
+		targetServerA.add(coap2coap);
 		targetServerA.add(coap2http);
 		targetServerA.start();
 	}


### PR DESCRIPTION
This re-adds code coap2coap support code that was removed during initial setup.